### PR TITLE
rm buffertools

### DIFF
--- a/lib/grip.js
+++ b/lib/grip.js
@@ -13,7 +13,6 @@
 var jwt = require('jwt-simple');
 var url = require('url');
 var querystring = require('querystring');
-var buffertools = require('buffertools');
 var grChannel = require('./channel');
 var grResponse = require('./response');
 var httpstreamformat = require('./httpstreamformat');
@@ -68,13 +67,13 @@ var decodeWebSocketEvents = function(body) {
         makeContentString = true;
     }
     while (start < body.length) {
-        var at = buffertools.indexOf(body, '\r\n', start);
+        var at = body.indexOf('\r\n', start)
         if (at == -1) {
             throw new Error('bad format');
         }
         var typeline = body.slice(start, at);
         start = at + 2;
-        at = buffertools.indexOf(typeline, ' ');
+        at = typeline.indexOf(' ')
         var e = null;
         if (at != -1) {
             var etype = typeline.slice(0, at);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+    "name": "grip",
+    "version": "1.2.7",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "agentkeepalive": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+            "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
+        },
+        "jwt-simple": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.1.tgz",
+            "integrity": "sha1-eeoBiRth3mto4T5nwLS1vak3spQ="
+        },
+        "pubcontrol": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pubcontrol/-/pubcontrol-1.1.1.tgz",
+            "integrity": "sha1-bNbVnlPwD3zfvFAHYQs+uKygpwM=",
+            "requires": {
+                "agentkeepalive": "2.2.0",
+                "jwt-simple": "0.5.1"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         }
     ],
     "main": "./lib/grip",
+    "scripts": {
+        "test": "node tests"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/fanout/node-grip.git"
@@ -31,7 +34,7 @@
     "dependencies": {
         "pubcontrol": "1.x",
         "jwt-simple": "0.x",
-	"buffertools": "2.x"
+        "buffertools": "2.x"
     },
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     ],
     "dependencies": {
         "pubcontrol": "1.x",
-        "jwt-simple": "0.x",
-        "buffertools": "2.x"
+        "jwt-simple": "0.x"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "engines": {
+        "node": ">=1.5.0"
+    }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,24 @@
+var fs = require('fs');
+var path = require('path')
+
+var TESTS_DIR = __dirname
+
+if (require.main === module) test()
+
+
+function getTestFiles() {
+    var thisFile = __filename
+    return fs.readdirSync(TESTS_DIR)
+        .filter(function (filename) {
+            return path.join(TESTS_DIR, filename) !== thisFile
+        })
+        .map(function (filename) {
+            return path.join(TESTS_DIR, filename)
+        })
+}
+
+function test () {
+    return getTestFiles().forEach(function (filepath) {
+        require(filepath)
+    })
+}

--- a/tests/websocketmessageformat_tests.js
+++ b/tests/websocketmessageformat_tests.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var grip = require('../lib/grip');
 var websocketmessageformat = require('../lib/websocketmessageformat');
 
 (function testInitialize() {


### PR DESCRIPTION
Because it uses node-gyp which makes `node_modules/` not-so-portable