### PR TITLE
Add typescript type declaration as index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,124 @@
+/// <reference types="node" />
+
+interface IParsedGripUri {
+  /** main URI of Grip */
+  control_uri: string;
+  /** Fanout realm-id or Grip Auth issuer */
+  control_iss?: string;
+  /** Secret key */
+  key?: string;
+}
+/** Parse a GRIP_URL value into the uri + parameters it encodes */
+// tslint:disable-next-line:completed-docs
+export function parseGripUri(uri: string): IParsedGripUri;
+export type WebSocketEventWithContentTypeName = "TEXT" | "BINARY" | "CLOSE";
+export type WebSocketEventWithoutContentTypeName =
+  | "OPEN"
+  | "PING"
+  | "PONG"
+  | "DISCONNECT";
+export type WebSocketEventTypeName =
+  | WebSocketEventWithContentTypeName
+  | WebSocketEventWithoutContentTypeName;
+export interface IWebSocketEventWithContent {
+  /** get content of event */
+  getContent(): string;
+  /** get event type */
+  getType(): WebSocketEventWithContentTypeName;
+}
+export interface IWebSocketEventWithoutContent {
+  /** get content of event */
+  getContent(): null;
+  /** get event type */
+  getType(): WebSocketEventWithoutContentTypeName;
+}
+/**
+ * Class representing one of the events part of the Websocket-Over-HTTP protocol.
+ * https://pushpin.org/docs/protocols/websocket-over-http/
+ */
+export class WebSocketEvent {
+  constructor(type: WebSocketEventTypeName, content?: string);
+  /** get content of event */
+  public getContent(): Buffer | null;
+  /** get event type */
+  public getType(): WebSocketEventTypeName;
+}
+// tslint:disable:completed-docs
+/** Translate an application/websocket-events string into WebSocketEvent objects */
+export function decodeWebSocketEvents(reqBody: string): WebSocketEvent[];
+/** Translate an array of WebSocketEvent objects into a string that conforms to application/websocket-events */
+export function encodeWebSocketEvents(events: WebSocketEvent[]): string;
+
+// https://github.com/fanout/node-grip/blob/master/lib/websocketcontext.js#L16
+export class WebSocketContext {
+  public id: string;
+  public inEvents: WebSocketEvent[];
+  public readIndex: number;
+  public accepted: boolean;
+  public closeCode: null | number;
+  public closed: boolean;
+  public outCloseCode: null | number;
+  public outEvents: WebSocketEvent[];
+  public origMeta: object;
+  public meta: object;
+  public prefix: string;
+  constructor(
+    id: string | undefined,
+    meta: object,
+    inEvents: WebSocketEvent[],
+    prefix?: string,
+  );
+  public isOpening(): boolean;
+  public accept(): void;
+  public close(code: number): void;
+  public canRecv(): boolean;
+  public recvRaw(): string | Buffer | null;
+  public recv(): string | null;
+  public send(message: string): void;
+  public sendBinary(message: string | Buffer): void;
+  public sendControl(message: string): void;
+  public subscribe(channel: string): void;
+  public unsubscribe(channel: string): void;
+  public detach(): void;
+}
+
+interface IPubControlItemExported {
+  id: string;
+  "prev-id": string;
+}
+interface IPubControlItemFormat {
+  name(): string;
+  // if content-bin, it's base64-encoded
+  export(): { content: string } | { "content-bin": string };
+}
+declare class PubControlItem {
+  public formats: IPubControlItemFormat[];
+  public id?: string;
+  public prevId?: string;
+  public export(): IPubControlItemExported;
+}
+type IPubControlCallback = (
+  success: boolean,
+  message: string,
+  context: object,
+) => void;
+interface IPubControlConfig {
+  control_iss?: string;
+  control_uri: string;
+  key?: string;
+}
+export class GripPubControl {
+  constructor(config: IPubControlConfig | IPubControlConfig[]);
+  public publish(
+    channel: string,
+    item: PubControlItem,
+    cb?: IPubControlCallback,
+  ): void;
+}
+
+export class WebSocketMessageFormat {
+  constructor(message: string | Buffer);
+  public name(): "ws-message";
+  // if content-bin, it's base64-encoded
+  public export(): { content: string } | { "content-bin": string };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,24 @@
 {
     "name": "grip",
-    "version": "1.2.7",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@types/node": {
+            "version": "12.0.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+            "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
+            "dev": true
+        },
         "agentkeepalive": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
             "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
+        },
+        "jspack": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/jspack/-/jspack-0.0.4.tgz",
+            "integrity": "sha1-Mt01x/3LPjRWwY+7fvntC8YjgXc="
         },
         "jwt-simple": {
             "version": "0.5.1",
@@ -19,8 +30,8 @@
             "resolved": "https://registry.npmjs.org/pubcontrol/-/pubcontrol-1.1.1.tgz",
             "integrity": "sha1-bNbVnlPwD3zfvFAHYQs+uKygpwM=",
             "requires": {
-                "agentkeepalive": "2.2.0",
-                "jwt-simple": "0.5.1"
+                "agentkeepalive": "2.x",
+                "jwt-simple": "0.x"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=1.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^12.0.4"
   }
 }


### PR DESCRIPTION
This will allow typescript libraries import this module with type-checking enabled instead of the depender having to opt-out of type checking or author their own types like I did [over here](https://github.com/fanout/apollo-demo/blob/7dd4642be0ceed6852eb04dcfec4abc755d771fb/src/%40types/grip/index.d.ts)
